### PR TITLE
fix deployment failing because faker is used on actual code

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5524,8 +5524,7 @@
     "faker": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
-      "dev": true
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
     },
     "fast-deep-equal": {
       "version": "2.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@emotion/core": "^10.0.17",
     "@emotion/styled": "^10.0.17",
     "axios": "^0.19.0",
+    "faker": "^4.1.0",
     "gsap": "^2.1.3",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
@@ -35,7 +36,6 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/react": "^9.1.4",
-    "faker": "^4.1.0"
+    "@testing-library/react": "^9.1.4"
   }
 }


### PR DESCRIPTION
This is a fix that should get phased out when replacing faker by actual user data. I tried passing `NODE_ENV='development'` on the build script but it messes with CRA. Let me know if there's another way you would do it